### PR TITLE
Feat/email username to unique string

### DIFF
--- a/docs/swagger-1.6.json
+++ b/docs/swagger-1.6.json
@@ -8,7 +8,7 @@
   ],
   "info": {
     "description": "This is the RouteMaker API",
-    "version": "1.5",
+    "version": "1.6",
     "title": "RouteMaker API",
     "contact": {
       "email": "yarkhinephyo@gmail.com"
@@ -208,7 +208,7 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "email": {
+                  "name": {
                     "format": "string"
                   }
                 }
@@ -251,7 +251,7 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "email": {
+                  "name": {
                     "format": "string"
                   }
                 }
@@ -1014,11 +1014,11 @@
       "Login": {
         "type": "object",
         "required": [
-          "email",
+          "name",
           "password"
         ],
         "properties": {
-          "email": {
+          "name": {
             "type": "string"
           },
           "password": {
@@ -1030,12 +1030,12 @@
       "ResetPassword": {
         "type": "object",
         "required": [
-          "email",
+          "name",
           "password",
           "code"
         ],
         "properties": {
-          "email": {
+          "name": {
             "type": "string"
           },
           "password": {

--- a/docs/swagger-1.6.json
+++ b/docs/swagger-1.6.json
@@ -1176,7 +1176,7 @@
         "properties": {
           "username": {
             "type": "string",
-            "example": "7cdddb23-a63d-4f17-be27-1f078b1ed302"
+            "example": "yarkhinephyo"
           },
           "comment": {
             "type": "string",
@@ -1187,10 +1187,6 @@
             "type": "integer",
             "format": "int32",
             "example": 1623466053
-          },
-          "displayName": {
-            "type": "string",
-            "example": "yarkhinephyo"
           }
         }
       },
@@ -1199,7 +1195,6 @@
         "required": [
           "username",
           "createdAt",
-          "displayName",
           "expiredTime",
           "routeName",
           "gymLocation",
@@ -1220,9 +1215,6 @@
           "createdAt": {
             "type": "string",
             "example": ""
-          },
-          "displayName": {
-            "type": "string"
           },
           "expiredTime": {
             "type": "string"
@@ -1303,7 +1295,7 @@
         "properties": {
           "username": {
             "type": "string",
-            "example": "7cdddb23-a63d-4f17-be27-1f078b1ed302"
+            "example": "yarkhinephyo"
           },
           "createdAt": {
             "type": "string",
@@ -1316,7 +1308,6 @@
         "required": [
           "username",
           "createdAt",
-          "displayName",
           "expiredTime",
           "routeName",
           "gymLocation",
@@ -1338,10 +1329,6 @@
           "createdAt": {
             "type": "string",
             "example": "2021-05-01T09:00:34.516Z"
-          },
-          "displayName": {
-            "type": "string",
-            "example": "yarkhinephyo"
           },
           "expiredTime": {
             "type": "string",
@@ -1420,7 +1407,7 @@
         "properties": {
           "username": {
             "type": "string",
-            "example": "7cdddb23-a63d-4f17-be27-1f078b1ed302"
+            "example": "yarkhinephyo"
           },
           "createdAt": {
             "type": "string",
@@ -1475,7 +1462,7 @@
         "properties": {
           "username": {
             "type": "string",
-            "example": "7cdddb23-a63d-4f17-be27-1f078b1ed302"
+            "example": "yarkhinephyo"
           },
           "createdAt": {
             "type": "string",
@@ -1511,7 +1498,6 @@
           "createdAt",
           "routeName",
           "gymLocation",
-          "routeURL",
           "publicGrade",
           "voteCount",
           "commentCount"
@@ -1527,9 +1513,6 @@
             "type": "string"
           },
           "gymLocation": {
-            "type": "string"
-          },
-          "displayName": {
             "type": "string"
           },
           "publicGrade": {

--- a/ionic_user_interface/src/providers.ts
+++ b/ionic_user_interface/src/providers.ts
@@ -5,7 +5,7 @@ import jwt_decode from 'jwt-decode';
 import { toastController } from '@ionic/vue';
 
 const isLoggedIn = ref(false);
-const userEmail = ref('');
+const username = ref('');
 const accessToken = ref('');
 const idToken = ref('');
 const isConfirmationNeeded = ref(false);
@@ -39,12 +39,12 @@ const forceLogout = async (): Promise<void> => {
     })
     .finally(() => {
       isLoggedIn.value = false;
-      userEmail.value = '';
+      username.value = '';
       accessToken.value = '';
       idToken.value = '';
       isConfirmationNeeded.value = false;
       localStorage.removeItem('isLoggedIn');
-      localStorage.removeItem('userEmail');
+      localStorage.removeItem('username');
       localStorage.removeItem('accessToken');
       localStorage.removeItem('idToken');
       localStorage.removeItem('isConfirmationNeeded');
@@ -97,13 +97,13 @@ const providers = {
     localStorage.setItem('isLoggedIn', loggedIn ? 'yes' : 'no');
     isLoggedIn.value = loggedIn;
   },
-  getUserEmail: (): Ref<string> => {
-    userEmail.value = localStorage.getItem('userEmail') ?? '';
-    return userEmail;
+  getUsername: (): Ref<string> => {
+    username.value = localStorage.getItem('username') ?? '';
+    return username;
   },
-  setUserEmail: (email: string): void => {
-    localStorage.setItem('userEmail', email);
-    userEmail.value = email;
+  setUsername: (name: string): void => {
+    localStorage.setItem('username', name);
+    username.value = name;
   },
   getAccessToken: (): Ref<string> => {
     accessToken.value = localStorage.getItem('accessToken') ?? '';

--- a/ionic_user_interface/src/providers.ts
+++ b/ionic_user_interface/src/providers.ts
@@ -6,6 +6,7 @@ import { toastController } from '@ionic/vue';
 
 const isLoggedIn = ref(false);
 const username = ref('');
+const userEmail = ref('');
 const accessToken = ref('');
 const idToken = ref('');
 const isConfirmationNeeded = ref(false);
@@ -40,11 +41,13 @@ const forceLogout = async (): Promise<void> => {
     .finally(() => {
       isLoggedIn.value = false;
       username.value = '';
+      userEmail.value = '';
       accessToken.value = '';
       idToken.value = '';
       isConfirmationNeeded.value = false;
       localStorage.removeItem('isLoggedIn');
       localStorage.removeItem('username');
+      localStorage.removeItem('userEmail');
       localStorage.removeItem('accessToken');
       localStorage.removeItem('idToken');
       localStorage.removeItem('isConfirmationNeeded');
@@ -105,6 +108,14 @@ const providers = {
     localStorage.setItem('username', name);
     username.value = name;
   },
+  getUserEmail: (): Ref<string> => {
+    userEmail.value = localStorage.getItem('userEmail') ?? '';
+    return userEmail;
+  },
+  setUserEmail: (email: string): void => {
+    localStorage.setItem('userEmail', email);
+    userEmail.value = email;
+  },
   getAccessToken: (): Ref<string> => {
     accessToken.value = localStorage.getItem('accessToken') ?? '';
     return accessToken;
@@ -121,7 +132,7 @@ const providers = {
     localStorage.setItem('idToken', token);
     idToken.value = token;
   },
-  getConformationNeeded: (): Ref<boolean> => {
+  getConfirmationNeeded: (): Ref<boolean> => {
     isConfirmationNeeded.value = localStorage.getItem('isConfirmationNeeded') === 'yes';
     return isConfirmationNeeded;
   },

--- a/ionic_user_interface/src/views/Confirm.vue
+++ b/ionic_user_interface/src/views/Confirm.vue
@@ -78,7 +78,7 @@ export default defineComponent({
     const msgBox: Ref<typeof MessageBox | null> = ref(null);
     const msgBoxColor = ref('danger');
     const confirmationCodeText = ref('');
-    const getUserEmail: () => Ref<string> = inject('getUserEmail', () => ref(''));
+    const getUsername: () => Ref<string> = inject('getUsername', () => ref(''));
     const setConfirmationNeeded: (confirmationNeeded: boolean) => void = inject(
       'setConfirmationNeeded',
       () => undefined,
@@ -105,7 +105,7 @@ export default defineComponent({
 
     onMounted(() => {
       msgBoxColor.value = 'medium';
-      msgBox.value?.showMsg(`A confirmation code has been sent to ${getUserEmail().value}`);
+      msgBox.value?.showMsg(`A confirmation code has been sent to the email`);
     });
 
     const onSubmit = (event: Event): boolean => {
@@ -122,7 +122,7 @@ export default defineComponent({
 
       axios
         .post(process.env.VUE_APP_USER_ENDPOINT_URL + '/user/confirm', {
-          email: getUserEmail().value,
+          name: getUsername().value,
           code: confirmationCodeText.value,
         })
         .then((response) => {

--- a/ionic_user_interface/src/views/Confirm.vue
+++ b/ionic_user_interface/src/views/Confirm.vue
@@ -79,6 +79,7 @@ export default defineComponent({
     const msgBoxColor = ref('danger');
     const confirmationCodeText = ref('');
     const getUsername: () => Ref<string> = inject('getUsername', () => ref(''));
+    const getUserEmail: () => Ref<string> = inject('getUserEmail', () => ref(''));
     const setConfirmationNeeded: (confirmationNeeded: boolean) => void = inject(
       'setConfirmationNeeded',
       () => undefined,
@@ -105,7 +106,7 @@ export default defineComponent({
 
     onMounted(() => {
       msgBoxColor.value = 'medium';
-      msgBox.value?.showMsg(`A confirmation code has been sent to the email`);
+      msgBox.value?.showMsg(`A confirmation code has been sent to ${getUserEmail().value}`);
     });
 
     const onSubmit = (event: Event): boolean => {

--- a/ionic_user_interface/src/views/Login.vue
+++ b/ionic_user_interface/src/views/Login.vue
@@ -112,7 +112,7 @@ export default defineComponent({
     });
 
     const isValidUsername = (username: string): boolean => {
-      return username.length >= 5 && usernamePattern.test(username);
+      return username.length >= 5 && username.length <= 20 && usernamePattern.test(username);
     };
 
     const isValidPassword = (password: string): boolean => {
@@ -128,7 +128,7 @@ export default defineComponent({
       // Invalid credentials
       if (!isValidUsername(usernameText.value)) {
         errorMsg.value?.showMsg(
-          'Username has to be at least 5 characters and contain only letters, numbers, and spaces',
+          'Username has to be between 5 to 20 characters and contains only letters, numbers, and spaces',
         );
         return false;
       }

--- a/ionic_user_interface/src/views/Login.vue
+++ b/ionic_user_interface/src/views/Login.vue
@@ -11,10 +11,10 @@
               <MessageBox ref="errorMsg" color="danger" class="rounded" />
               <form @submit="onSubmit">
                 <ion-item class="rounded">
-                  <ion-label position="stacked">Email</ion-label>
+                  <ion-label position="stacked">Username</ion-label>
                   <ion-input
                     @keyup.enter="clickLoginButton"
-                    v-model="emailText"
+                    v-model="usernameText"
                     inputmode="email"
                     name="email"
                     type="text"
@@ -93,18 +93,17 @@ export default defineComponent({
   setup() {
     const router = useRouter();
     // Email validation regex taken from https://stackoverflow.com/questions/46155/how-to-validate-an-email-address-in-javascript
-    const emailPattern =
-      /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    const usernamePattern = /^[a-zA-Z0-9 ]*$/;
     const setLoggedIn: (loggedIn: boolean) => void = inject('setLoggedIn', () => undefined);
-    const getUserEmail: () => Ref<string> = inject('getUserEmail', () => ref(''));
-    const setUserEmail: (email: string) => void = inject('setUserEmail', () => undefined);
+    const getUsername: () => Ref<string> = inject('getUsername', () => ref(''));
+    const setUsername: (email: string) => void = inject('setUsername', () => undefined);
     const setAccessToken: (accessToken: string) => void = inject('setAccessToken', () => undefined);
     const setIdToken: (idToken: string) => void = inject('setIdToken', () => undefined);
     const setConfirmationNeeded: (confirmationNeeded: boolean) => void = inject(
       'setConfirmationNeeded',
       () => undefined,
     );
-    const emailText = ref('');
+    const usernameText = ref('');
     const passwordText = ref('');
     const errorMsg: Ref<typeof MessageBox | null> = ref(null);
 
@@ -112,8 +111,8 @@ export default defineComponent({
       errorMsg.value?.close();
     });
 
-    const isValidEmail = (email: string): boolean => {
-      return emailPattern.test(email.toLowerCase());
+    const isValidUsername = (username: string): boolean => {
+      return username.length >= 5 && usernamePattern.test(username);
     };
 
     const isValidPassword = (password: string): boolean => {
@@ -124,11 +123,13 @@ export default defineComponent({
       event.preventDefault();
       errorMsg.value?.close();
 
-      emailText.value = emailText.value.trim();
+      usernameText.value = usernameText.value.trim();
 
       // Invalid credentials
-      if (!isValidEmail(emailText.value)) {
-        errorMsg.value?.showMsg('Invalid email');
+      if (!isValidUsername(usernameText.value)) {
+        errorMsg.value?.showMsg(
+          'Username has to be at least 5 characters and contain only letters, numbers, and spaces',
+        );
         return false;
       }
       if (!isValidPassword(passwordText.value)) {
@@ -137,10 +138,10 @@ export default defineComponent({
       }
 
       // Valid credentials
-      setUserEmail(emailText.value);
+      setUsername(usernameText.value);
       axios
         .post(process.env.VUE_APP_USER_ENDPOINT_URL + '/user/login', {
-          email: getUserEmail().value,
+          name: getUsername().value,
           password: passwordText.value,
         })
         .then((response) => {
@@ -198,7 +199,7 @@ export default defineComponent({
     return {
       onSubmit,
       clickLoginButton,
-      emailText,
+      usernameText,
       passwordText,
       errorMsg,
     };

--- a/ionic_user_interface/src/views/Login.vue
+++ b/ionic_user_interface/src/views/Login.vue
@@ -95,8 +95,8 @@ export default defineComponent({
     // Email validation regex taken from https://stackoverflow.com/questions/46155/how-to-validate-an-email-address-in-javascript
     const usernamePattern = /^[a-zA-Z0-9 ]*$/;
     const setLoggedIn: (loggedIn: boolean) => void = inject('setLoggedIn', () => undefined);
-    const getUsername: () => Ref<string> = inject('getUsername', () => ref(''));
-    const setUsername: (email: string) => void = inject('setUsername', () => undefined);
+    const setUserEmail: (email: string) => void = inject('setUserEmail', () => undefined);
+    const setUsername: (name: string) => void = inject('setUsername', () => undefined);
     const setAccessToken: (accessToken: string) => void = inject('setAccessToken', () => undefined);
     const setIdToken: (idToken: string) => void = inject('setIdToken', () => undefined);
     const setConfirmationNeeded: (confirmationNeeded: boolean) => void = inject(
@@ -141,7 +141,7 @@ export default defineComponent({
       setUsername(usernameText.value);
       axios
         .post(process.env.VUE_APP_USER_ENDPOINT_URL + '/user/login', {
-          name: getUsername().value,
+          name: usernameText.value,
           password: passwordText.value,
         })
         .then((response) => {
@@ -179,6 +179,7 @@ export default defineComponent({
               errorMsg.value?.showMsg('Wrong email or password');
             } else if (error.response.data.Message === 'UserNotConfirmedException') {
               setConfirmationNeeded(true);
+              setUserEmail(error.response.data.Email);
               router.push('/confirm');
             } else {
               console.error(error.response.data);

--- a/ionic_user_interface/src/views/Profile.vue
+++ b/ionic_user_interface/src/views/Profile.vue
@@ -84,21 +84,20 @@ export default defineComponent({
   setup() {
     const router = useRouter();
     const forceLogout: () => Promise<void> = inject('forceLogout', () => Promise.resolve());
-    const getUserEmail: () => Ref<string> = inject('getUserEmail', () => ref(''));
+    const getUsername: () => Ref<string> = inject('getUsername', () => ref(''));
     const getAccessToken: () => Ref<string> = inject('getAccessToken', () => ref(''));
     const getIdToken: () => Ref<string> = inject('getIdToken', () => ref(''));
-    const emailText = getUserEmail();
+    const usernameText = getUsername();
     const idToken = getIdToken();
-    const usernameText = computed(() => {
+    const emailText = computed(() => {
       if (idToken.value === '') {
         return '';
       }
       try {
         const idObject: {
-          name: string;
           email: string;
         } = jwt_decode(idToken.value);
-        return idObject.name;
+        return idObject.email;
       } catch (error) {
         console.error(error);
         forceLogout();

--- a/ionic_user_interface/src/views/Signup.vue
+++ b/ionic_user_interface/src/views/Signup.vue
@@ -123,8 +123,8 @@ export default defineComponent({
     const emailPattern =
       /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     const usernamePattern = /^[a-zA-Z0-9 ]*$/;
-    const getUserEmail: () => Ref<string> = inject('getUserEmail', () => ref(''));
-    const setUserEmail: (email: string) => void = inject('setUserEmail', () => undefined);
+    const getUsername: () => Ref<string> = inject('getUsername', () => ref(''));
+    const setUsername: (email: string) => void = inject('setUsername', () => undefined);
     const setConfirmationNeeded: (confirmationNeeded: boolean) => void = inject(
       'setConfirmationNeeded',
       () => undefined,
@@ -176,11 +176,11 @@ export default defineComponent({
       }
 
       // Valid credentials
-      setUserEmail(emailText.value);
+      setUsername(usernameText.value);
       axios
         .post(process.env.VUE_APP_USER_ENDPOINT_URL + '/user/signup', {
-          name: usernameText.value,
-          email: getUserEmail().value,
+          name: getUsername().value,
+          email: emailText.value,
           password: passwordText.value,
         })
         .then((response) => {
@@ -197,7 +197,7 @@ export default defineComponent({
             // The request was made and the server responded with a status code
             // that falls out of the range of 2xx
             if (error.response.data.Message === 'UsernameExistsException') {
-              errorMsg.value?.showMsg('Account already exists, please login!');
+              errorMsg.value?.showMsg('Username exists!');
             } else {
               console.error(error.response.data);
             }

--- a/ionic_user_interface/src/views/Signup.vue
+++ b/ionic_user_interface/src/views/Signup.vue
@@ -145,7 +145,7 @@ export default defineComponent({
     };
 
     const isValidUsername = (username: string): boolean => {
-      return username.length >= 5 && usernamePattern.test(username);
+      return username.length >= 5 && username.length <= 20 && usernamePattern.test(username);
     };
 
     const onSubmit = (event: Event): boolean => {
@@ -162,7 +162,7 @@ export default defineComponent({
       }
       if (!isValidUsername(usernameText.value)) {
         errorMsg.value?.showMsg(
-          'Username has to be at least 5 characters and contain only letters, numbers, and spaces',
+          'Username has to be between 5 to 20 characters and contains only letters, numbers, and spaces',
         );
         return false;
       }

--- a/ionic_user_interface/src/views/Signup.vue
+++ b/ionic_user_interface/src/views/Signup.vue
@@ -123,8 +123,8 @@ export default defineComponent({
     const emailPattern =
       /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
     const usernamePattern = /^[a-zA-Z0-9 ]*$/;
-    const getUsername: () => Ref<string> = inject('getUsername', () => ref(''));
-    const setUsername: (email: string) => void = inject('setUsername', () => undefined);
+    const setUsername: (name: string) => void = inject('setUsername', () => undefined);
+    const setUserEmail: (email: string) => void = inject('setUserEmail', () => undefined);
     const setConfirmationNeeded: (confirmationNeeded: boolean) => void = inject(
       'setConfirmationNeeded',
       () => undefined,
@@ -177,9 +177,10 @@ export default defineComponent({
 
       // Valid credentials
       setUsername(usernameText.value);
+      setUserEmail(emailText.value);
       axios
         .post(process.env.VUE_APP_USER_ENDPOINT_URL + '/user/signup', {
-          name: getUsername().value,
+          name: usernameText.value,
           email: emailText.value,
           password: passwordText.value,
         })

--- a/lambda_backend/cognito_setup/serverless.yml
+++ b/lambda_backend/cognito_setup/serverless.yml
@@ -22,7 +22,7 @@ resources:
       Type: AWS::Cognito::UserPool
       Properties:
         UserPoolName: ${self:service}-${self:provider.stage}-user-pool
-        UsernameAttributes:
+        AliasAttributes:
           - email
         AutoVerifiedAttributes:
           - email

--- a/lambda_backend/database_setup/serverless.yml
+++ b/lambda_backend/database_setup/serverless.yml
@@ -46,7 +46,6 @@ resources:
                 - publicGrade
                 - voteCount
                 - commentCount
-                - displayName
               ProjectionType: INCLUDE
             ProvisionedThroughput:
               ReadCapacityUnits: ${self:custom._routeDataTableGSI.ReadCapacityUnits.${self:custom.stage}}

--- a/lambda_backend/postman_collections/Bouldering - Route.postman_collection.json
+++ b/lambda_backend/postman_collections/Bouldering - Route.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "_postman_id": "518d70e5-7e93-4c11-b755-10f1809763ec",
     "name": "Bouldering - Route",
-    "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
     {
@@ -30,9 +30,13 @@
       "request": {
         "auth": {
           "type": "bearer",
-          "bearer": {
-            "token": "eyJraWQiOiJvWnBBeWVqKzJEdGk0REUrczFpZnAycURUU0ZnNWVwSFNId3hIMDlcL1VMcz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJlZmYzZDYzYi0wY2QyLTRmNmYtOTJkYS04OGRjZTYzMDA0ZjAiLCJldmVudF9pZCI6ImY3MjEwYTI5LTk5MDYtNDUzZC04YzliLTg5YmZjNDRhYjNiMCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MjM3NjAzNDcsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV8xN0VWUXloODIiLCJleHAiOjE2MjM4NDY3NDcsImlhdCI6MTYyMzc2MDM0OCwianRpIjoiZDlmODI5YzItNTliZi00Yjg3LWI1Y2ItMDNlOWI5NWU4YWQ5IiwiY2xpZW50X2lkIjoiZzVwNHZxNjFtYmZjbWVzb282dnNqa2c2cCIsInVzZXJuYW1lIjoiZWZmM2Q2M2ItMGNkMi00ZjZmLTkyZGEtODhkY2U2MzAwNGYwIn0.mpbkg1GEWpQvgsTNR89QLnbNLgZOJjHMJvWoVSlnXTwQUW3eAMsdLfB7OuVZ-Szj1Hg36t7KxSkznAbFHpPbk83kUoHM0TIPO9dlETiH04YvJBdHB_N6HorhST2lAuZS9cHzHlirVrkn9l0V6Tgq5nQ5Lin_6HsgC5V5WgccZ695hS_QMZ5iZ5r6jvan8-Q5vnUO9wnwoMKXd5N584Et1Fcr_V7N17Y0XHmzpCAZezrFHlP8Baf0ZfPwA8yAVZDgZVIPhn7UtJibe-F2aosjZRVli1eYJcaerPFavDJ2NKwKSAcU4eIV9hw7nqheI_R5_hm1QI6T5onAcfE-EK33_w"
-          }
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "type": "string"
+            }
+          ]
         },
         "method": "POST",
         "header": [
@@ -78,7 +82,12 @@
             }
           ]
         },
-        "url": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/new"
+        "url": {
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/new",
+          "protocol": "https",
+          "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "route", "new"]
+        }
       },
       "response": []
     },
@@ -87,9 +96,13 @@
       "request": {
         "auth": {
           "type": "bearer",
-          "bearer": {
-            "token": "eyJraWQiOiJvWnBBeWVqKzJEdGk0REUrczFpZnAycURUU0ZnNWVwSFNId3hIMDlcL1VMcz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJlZmYzZDYzYi0wY2QyLTRmNmYtOTJkYS04OGRjZTYzMDA0ZjAiLCJldmVudF9pZCI6ImY3MjEwYTI5LTk5MDYtNDUzZC04YzliLTg5YmZjNDRhYjNiMCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MjM3NjAzNDcsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV8xN0VWUXloODIiLCJleHAiOjE2MjM4NDY3NDcsImlhdCI6MTYyMzc2MDM0OCwianRpIjoiZDlmODI5YzItNTliZi00Yjg3LWI1Y2ItMDNlOWI5NWU4YWQ5IiwiY2xpZW50X2lkIjoiZzVwNHZxNjFtYmZjbWVzb282dnNqa2c2cCIsInVzZXJuYW1lIjoiZWZmM2Q2M2ItMGNkMi00ZjZmLTkyZGEtODhkY2U2MzAwNGYwIn0.mpbkg1GEWpQvgsTNR89QLnbNLgZOJjHMJvWoVSlnXTwQUW3eAMsdLfB7OuVZ-Szj1Hg36t7KxSkznAbFHpPbk83kUoHM0TIPO9dlETiH04YvJBdHB_N6HorhST2lAuZS9cHzHlirVrkn9l0V6Tgq5nQ5Lin_6HsgC5V5WgccZ695hS_QMZ5iZ5r6jvan8-Q5vnUO9wnwoMKXd5N584Et1Fcr_V7N17Y0XHmzpCAZezrFHlP8Baf0ZfPwA8yAVZDgZVIPhn7UtJibe-F2aosjZRVli1eYJcaerPFavDJ2NKwKSAcU4eIV9hw7nqheI_R5_hm1QI6T5onAcfE-EK33_w"
-          }
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "type": "string"
+            }
+          ]
         },
         "method": "DELETE",
         "header": [
@@ -101,18 +114,18 @@
           }
         ],
         "url": {
-          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route?createdAt=2021-06-15T12:49:31.052Z&username=eff3d63b-0cd2-4f6f-92da-88dce63004f0",
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route?createdAt=2021-06-16T15:11:18.602Z&username=yarkhinephyo",
           "protocol": "https",
           "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
           "path": ["dev", "route"],
           "query": [
             {
               "key": "createdAt",
-              "value": "2021-06-15T12:49:31.052Z"
+              "value": "2021-06-16T15:11:18.602Z"
             },
             {
               "key": "username",
-              "value": "eff3d63b-0cd2-4f6f-92da-88dce63004f0"
+              "value": "yarkhinephyo"
             }
           ]
         }
@@ -144,22 +157,31 @@
       "request": {
         "auth": {
           "type": "bearer",
-          "bearer": {
-            "token": "eyJraWQiOiJvWnBBeWVqKzJEdGk0REUrczFpZnAycURUU0ZnNWVwSFNId3hIMDlcL1VMcz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiI5YTEyNTFhMi01NGE5LTQ2YzgtYTk4Yy03YmJkMWU5NTAyYWMiLCJldmVudF9pZCI6IjYwNDBlNTZhLWE4OTctNDg2Ny05N2E2LTVlYmNkODQ4OGI3MyIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MjM2MDExOTYsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV8xN0VWUXloODIiLCJleHAiOjE2MjM2ODc1OTYsImlhdCI6MTYyMzYwMTE5NiwianRpIjoiNzUwOGFmNGItNTk3Mi00MmY0LWI5ODItMDczZWYxYWM1YzRjIiwiY2xpZW50X2lkIjoiZzVwNHZxNjFtYmZjbWVzb282dnNqa2c2cCIsInVzZXJuYW1lIjoiOWExMjUxYTItNTRhOS00NmM4LWE5OGMtN2JiZDFlOTUwMmFjIn0.Ez3ldWKm2J5ZdR8W-_Xzu8C10N60fYcFaJnkKNB_r-3G0w0UEoTCV7_LujTECLcxLx2WjEQ1zX9i1boRx_ebU8Tg7H0wz2-95onSQcYu5fAkCuKRT13a7hjhHeWw1wCCn000WKDOmqXn2gUNd2oeQ7Bf7fULVOFze5-kgsh1eAKntfuhhclCzPFkPnUHK8X_34Y82IjpdZvlrz3sCy2JIRbAuSXHrUWyCBtL57KXTIXaFtE_mEep_iFvpp1mHw3kRnwy6QBmYgMRcSV8UNkpvR0aiMV_ayvqjBDHu4vpHUOZ46RYY210rc8AlE0BaPW-AFfq9Vdf0NL5RZTJhBWVag"
-          }
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiZDMwMWE3ZjUtN2MyZi00YThmLWFmODItNmRmNWRkODZhNGJhIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiIxZTU0NGQ1ZS1mMDk4LTQ3ODQtOGQ4MC0xNzEyNjVhYzQxMDAiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU0NjY4LCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQxMDY4LCJpYXQiOjE2MjM4NTQ2NjgsImp0aSI6IjY0ZDUwNGQ3LTU1MWUtNGE1Ny1iMDI5LTc5ZjU0YjQ5MzJjMyIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.hIyVrUvJMOnI_dnYJOuD-yiTFhCUnH9eWy0NoU1KmYTwSS58sETeG9ezy--0EjRHDgOLtP7f4HofeOiour9eUglUMB1AciXcA_X5f5Il9aaWxHeVhpG0WRygIFNACu_jEKJxm1nCVAi-6mGw0u8gsLOWSf_VWOtxuWihMjI5eZzLJqnYrA5AfSb5f9IuC6SnDZgtlS5Y6oBp4ZvCxrNedVJTFSxVv9_0BVDK160d9KCnocAuw856khEM6Gbg-LkVeWVPXyx006GszKgQI4bMMl3qk0PPuw4uYZ7YWJ1UlSA1vZ1SmGzQofVoPjHx3ENcFV64gXNI1-LrXfG9its9VA",
+              "type": "string"
+            }
+          ]
         },
         "method": "POST",
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"username\": \"eff3d63b-0cd2-4f6f-92da-88dce63004f0\",\r\n    \"createdAt\": \"2021-06-15T12:33:02.058Z\"\r\n}",
+          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-16T15:11:18.602Z\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
             }
           }
         },
-        "url": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details"
+        "url": {
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details",
+          "protocol": "https",
+          "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "route", "details"]
+        }
       },
       "response": []
     },
@@ -168,22 +190,31 @@
       "request": {
         "auth": {
           "type": "bearer",
-          "bearer": {
-            "token": "eyJraWQiOiJYTmk5ZFwvY1JcL3haTXJ4dytOQVJPemNpSUNacUJzdU90WXc1ME9uSWNzc0k9IiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJiMGJjYTRkMy0xODYyLTQ4M2UtOTcyMi05MDQxOWYyMDdjMzkiLCJldmVudF9pZCI6ImVmODRkYWQwLTE4YTgtNGVmZi1hZTY3LWQxNzlkMGVhZTk0MCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MTk5MjQ5OTEsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV9JMFk5WEZpUTkiLCJleHAiOjE2MTk5NDY1OTEsImlhdCI6MTYxOTkyNDk5MSwianRpIjoiYTIwZjkwZTAtZmRiNC00OGM4LWFkZjktZTI4MWY5OTkxOWFjIiwiY2xpZW50X2lkIjoiNTJjZHI4MTJtczFldjdmcDZsdnZscHJzMWMiLCJ1c2VybmFtZSI6ImIwYmNhNGQzLTE4NjItNDgzZS05NzIyLTkwNDE5ZjIwN2MzOSJ9.TlhxAz_RTUA-kaMmIal7hr-xfpGhsmHi_X5qHJzze0jIoAfM_0K4LDZY80QarRDRAPBzUse9EjejwsU1wuPzeMVbv4b0-2IDAV5dh1BMyBaY0OoPRIexmF9cVpoxsbMEPVh-XNziYF9ILDOGCcJ33W-B2HeNX9AEmHTd1uqJinL70ocH5aHU6PkCLAW-40552NV7dNrd4U4v0ARqJg4hZyfkfu5Cf3YYAYwOY9aIZvWPn68PUO33iWx9J-F290s0hgU7-USEEYifgyah68FxXhUQp9E4hwp81CQgHu36HdZq-YZN0hBQene7GfaPNIQI0hk7LVlfj1CS8Xv2OHZpMQ"
-          }
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "type": "string"
+            }
+          ]
         },
         "method": "POST",
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"username\": \"b0bca4d3-1862-483e-9722-90419f207c39\",\r\n    \"createdAt\": \"2021-05-02T04:05:37.072Z\"\r\n}",
+          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-16T15:11:18.602Z\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
             }
           }
         },
-        "url": "https://3xzyacsfo6.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/vote"
+        "url": {
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/vote",
+          "protocol": "https",
+          "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "route", "details", "vote"]
+        }
       },
       "response": []
     },
@@ -192,42 +223,37 @@
       "request": {
         "auth": {
           "type": "bearer",
-          "bearer": {
-            "token": "eyJraWQiOiJvWnBBeWVqKzJEdGk0REUrczFpZnAycURUU0ZnNWVwSFNId3hIMDlcL1VMcz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJlZmYzZDYzYi0wY2QyLTRmNmYtOTJkYS04OGRjZTYzMDA0ZjAiLCJldmVudF9pZCI6ImY3MjEwYTI5LTk5MDYtNDUzZC04YzliLTg5YmZjNDRhYjNiMCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MjM3NjAzNDcsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV8xN0VWUXloODIiLCJleHAiOjE2MjM4NDY3NDcsImlhdCI6MTYyMzc2MDM0OCwianRpIjoiZDlmODI5YzItNTliZi00Yjg3LWI1Y2ItMDNlOWI5NWU4YWQ5IiwiY2xpZW50X2lkIjoiZzVwNHZxNjFtYmZjbWVzb282dnNqa2c2cCIsInVzZXJuYW1lIjoiZWZmM2Q2M2ItMGNkMi00ZjZmLTkyZGEtODhkY2U2MzAwNGYwIn0.mpbkg1GEWpQvgsTNR89QLnbNLgZOJjHMJvWoVSlnXTwQUW3eAMsdLfB7OuVZ-Szj1Hg36t7KxSkznAbFHpPbk83kUoHM0TIPO9dlETiH04YvJBdHB_N6HorhST2lAuZS9cHzHlirVrkn9l0V6Tgq5nQ5Lin_6HsgC5V5WgccZ695hS_QMZ5iZ5r6jvan8-Q5vnUO9wnwoMKXd5N584Et1Fcr_V7N17Y0XHmzpCAZezrFHlP8Baf0ZfPwA8yAVZDgZVIPhn7UtJibe-F2aosjZRVli1eYJcaerPFavDJ2NKwKSAcU4eIV9hw7nqheI_R5_hm1QI6T5onAcfE-EK33_w"
-          }
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "type": "string"
+            }
+          ]
         },
         "method": "DELETE",
         "header": [],
-        "body": {
-          "mode": "raw",
-          "raw": "",
-          "options": {
-            "raw": {
-              "language": "json"
-            }
-          }
-        },
         "url": {
-          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/comment?username=eff3d63b-0cd2-4f6f-92da-88dce63004f0&createdAt=2021-06-15T12:33:02.058Z&commentUsername=eff3d63b-0cd2-4f6f-92da-88dce63004f0&timestamp=1623760433398",
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/comment?username=yarkhinephyo&createdAt=2021-06-16T15:11:18.602Z&commentUsername=yarkhinephyo&timestamp=1623856552615",
           "protocol": "https",
           "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
           "path": ["dev", "route", "details", "comment"],
           "query": [
             {
               "key": "username",
-              "value": "eff3d63b-0cd2-4f6f-92da-88dce63004f0"
+              "value": "yarkhinephyo"
             },
             {
               "key": "createdAt",
-              "value": "2021-06-15T12:33:02.058Z"
+              "value": "2021-06-16T15:11:18.602Z"
             },
             {
               "key": "commentUsername",
-              "value": "eff3d63b-0cd2-4f6f-92da-88dce63004f0"
+              "value": "yarkhinephyo"
             },
             {
               "key": "timestamp",
-              "value": "1623760433398"
+              "value": "1623856552615"
             }
           ]
         }
@@ -239,22 +265,31 @@
       "request": {
         "auth": {
           "type": "bearer",
-          "bearer": {
-            "token": "eyJraWQiOiJYTmk5ZFwvY1JcL3haTXJ4dytOQVJPemNpSUNacUJzdU90WXc1ME9uSWNzc0k9IiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJiMGJjYTRkMy0xODYyLTQ4M2UtOTcyMi05MDQxOWYyMDdjMzkiLCJldmVudF9pZCI6ImVmODRkYWQwLTE4YTgtNGVmZi1hZTY3LWQxNzlkMGVhZTk0MCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MTk5MjQ5OTEsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV9JMFk5WEZpUTkiLCJleHAiOjE2MTk5NDY1OTEsImlhdCI6MTYxOTkyNDk5MSwianRpIjoiYTIwZjkwZTAtZmRiNC00OGM4LWFkZjktZTI4MWY5OTkxOWFjIiwiY2xpZW50X2lkIjoiNTJjZHI4MTJtczFldjdmcDZsdnZscHJzMWMiLCJ1c2VybmFtZSI6ImIwYmNhNGQzLTE4NjItNDgzZS05NzIyLTkwNDE5ZjIwN2MzOSJ9.TlhxAz_RTUA-kaMmIal7hr-xfpGhsmHi_X5qHJzze0jIoAfM_0K4LDZY80QarRDRAPBzUse9EjejwsU1wuPzeMVbv4b0-2IDAV5dh1BMyBaY0OoPRIexmF9cVpoxsbMEPVh-XNziYF9ILDOGCcJ33W-B2HeNX9AEmHTd1uqJinL70ocH5aHU6PkCLAW-40552NV7dNrd4U4v0ARqJg4hZyfkfu5Cf3YYAYwOY9aIZvWPn68PUO33iWx9J-F290s0hgU7-USEEYifgyah68FxXhUQp9E4hwp81CQgHu36HdZq-YZN0hBQene7GfaPNIQI0hk7LVlfj1CS8Xv2OHZpMQ"
-          }
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "type": "string"
+            }
+          ]
         },
         "method": "POST",
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"username\": \"b0bca4d3-1862-483e-9722-90419f207c39\",\r\n    \"createdAt\": \"2021-05-02T04:46:05.583Z\",\r\n    \"grade\": 7\r\n}",
+          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-16T15:11:18.602Z\",\r\n    \"grade\": 7\r\n}",
           "options": {
             "raw": {
               "language": "json"
             }
           }
         },
-        "url": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/grade"
+        "url": {
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/grade",
+          "protocol": "https",
+          "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "route", "details", "grade"]
+        }
       },
       "response": []
     },
@@ -263,22 +298,31 @@
       "request": {
         "auth": {
           "type": "bearer",
-          "bearer": {
-            "token": "eyJraWQiOiJvWnBBeWVqKzJEdGk0REUrczFpZnAycURUU0ZnNWVwSFNId3hIMDlcL1VMcz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJlZmYzZDYzYi0wY2QyLTRmNmYtOTJkYS04OGRjZTYzMDA0ZjAiLCJldmVudF9pZCI6ImY3MjEwYTI5LTk5MDYtNDUzZC04YzliLTg5YmZjNDRhYjNiMCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MjM3NjAzNDcsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV8xN0VWUXloODIiLCJleHAiOjE2MjM4NDY3NDcsImlhdCI6MTYyMzc2MDM0OCwianRpIjoiZDlmODI5YzItNTliZi00Yjg3LWI1Y2ItMDNlOWI5NWU4YWQ5IiwiY2xpZW50X2lkIjoiZzVwNHZxNjFtYmZjbWVzb282dnNqa2c2cCIsInVzZXJuYW1lIjoiZWZmM2Q2M2ItMGNkMi00ZjZmLTkyZGEtODhkY2U2MzAwNGYwIn0.mpbkg1GEWpQvgsTNR89QLnbNLgZOJjHMJvWoVSlnXTwQUW3eAMsdLfB7OuVZ-Szj1Hg36t7KxSkznAbFHpPbk83kUoHM0TIPO9dlETiH04YvJBdHB_N6HorhST2lAuZS9cHzHlirVrkn9l0V6Tgq5nQ5Lin_6HsgC5V5WgccZ695hS_QMZ5iZ5r6jvan8-Q5vnUO9wnwoMKXd5N584Et1Fcr_V7N17Y0XHmzpCAZezrFHlP8Baf0ZfPwA8yAVZDgZVIPhn7UtJibe-F2aosjZRVli1eYJcaerPFavDJ2NKwKSAcU4eIV9hw7nqheI_R5_hm1QI6T5onAcfE-EK33_w"
-          }
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiNmRlNWZkMmMtOTYzNS00ZTk0LThlZGUtYzJhNTAzZjE1YjgwIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiI0N2M1ZjdjNS0zMzIzLTQyOTgtYmU5NS05NWUxMjg5NWRjMzMiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU1ODIyLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQyMjIyLCJpYXQiOjE2MjM4NTU4MjIsImp0aSI6ImQ5YWFmMGU0LTFlYTYtNGNkNy04NzhhLTBjNDhkYWYxYTdjNSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.jbP4LNY9jI-OAPeU-dZlNBuOBTv_lhIWX9d8KvUAG00LfkJKp3erIPHsaPKo8MVNPY2Ia0DnpIha-pPn9aLu1cUj4XP9dxYIgScifgwjANS2sAM04AdtNSyPSfef_YRX4lHOxnilr7FnqhdRvGFhL3di1nOE46sT5q18stmdh6k93YHhMfMDNa4b1LZx21t1zanQ36GQTZQTu4YHFgEiKlnCRNjirbyT8Hr1fEl7K6XLgBbG-nEnnoh33-26HNjYVMXdo-DQbYIruCpa_H84Opf-Qfdn1p-G1c_-6ZMK31iOD1lN46krHX6p_IHq0jx_OZis7o0pw__anhHcIkSj3w",
+              "type": "string"
+            }
+          ]
         },
         "method": "POST",
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"username\": \"eff3d63b-0cd2-4f6f-92da-88dce63004f0\",\r\n    \"createdAt\": \"2021-06-15T12:33:02.058Z\",\r\n    \"comment\": \"This is a comment by me and this cannot be more than 150 chars\"\r\n}",
+          "raw": "{\r\n    \"username\": \"yarkhinephyo\",\r\n    \"createdAt\": \"2021-06-16T15:11:18.602Z\",\r\n    \"comment\": \"This is a comment by me and this cannot be more than 150 chars\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
             }
           }
         },
-        "url": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/comment"
+        "url": {
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/comment",
+          "protocol": "https",
+          "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "route", "details", "comment"]
+        }
       },
       "response": []
     },
@@ -287,9 +331,13 @@
       "request": {
         "auth": {
           "type": "bearer",
-          "bearer": {
-            "token": "eyJraWQiOiJYTmk5ZFwvY1JcL3haTXJ4dytOQVJPemNpSUNacUJzdU90WXc1ME9uSWNzc0k9IiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJiMGJjYTRkMy0xODYyLTQ4M2UtOTcyMi05MDQxOWYyMDdjMzkiLCJldmVudF9pZCI6ImVmODRkYWQwLTE4YTgtNGVmZi1hZTY3LWQxNzlkMGVhZTk0MCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MTk5MjQ5OTEsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV9JMFk5WEZpUTkiLCJleHAiOjE2MTk5NDY1OTEsImlhdCI6MTYxOTkyNDk5MSwianRpIjoiYTIwZjkwZTAtZmRiNC00OGM4LWFkZjktZTI4MWY5OTkxOWFjIiwiY2xpZW50X2lkIjoiNTJjZHI4MTJtczFldjdmcDZsdnZscHJzMWMiLCJ1c2VybmFtZSI6ImIwYmNhNGQzLTE4NjItNDgzZS05NzIyLTkwNDE5ZjIwN2MzOSJ9.TlhxAz_RTUA-kaMmIal7hr-xfpGhsmHi_X5qHJzze0jIoAfM_0K4LDZY80QarRDRAPBzUse9EjejwsU1wuPzeMVbv4b0-2IDAV5dh1BMyBaY0OoPRIexmF9cVpoxsbMEPVh-XNziYF9ILDOGCcJ33W-B2HeNX9AEmHTd1uqJinL70ocH5aHU6PkCLAW-40552NV7dNrd4U4v0ARqJg4hZyfkfu5Cf3YYAYwOY9aIZvWPn68PUO33iWx9J-F290s0hgU7-USEEYifgyah68FxXhUQp9E4hwp81CQgHu36HdZq-YZN0hBQene7GfaPNIQI0hk7LVlfj1CS8Xv2OHZpMQ"
-          }
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJraWQiOiJYTmk5ZFwvY1JcL3haTXJ4dytOQVJPemNpSUNacUJzdU90WXc1ME9uSWNzc0k9IiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiJiMGJjYTRkMy0xODYyLTQ4M2UtOTcyMi05MDQxOWYyMDdjMzkiLCJldmVudF9pZCI6ImVmODRkYWQwLTE4YTgtNGVmZi1hZTY3LWQxNzlkMGVhZTk0MCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MTk5MjQ5OTEsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV9JMFk5WEZpUTkiLCJleHAiOjE2MTk5NDY1OTEsImlhdCI6MTYxOTkyNDk5MSwianRpIjoiYTIwZjkwZTAtZmRiNC00OGM4LWFkZjktZTI4MWY5OTkxOWFjIiwiY2xpZW50X2lkIjoiNTJjZHI4MTJtczFldjdmcDZsdnZscHJzMWMiLCJ1c2VybmFtZSI6ImIwYmNhNGQzLTE4NjItNDgzZS05NzIyLTkwNDE5ZjIwN2MzOSJ9.TlhxAz_RTUA-kaMmIal7hr-xfpGhsmHi_X5qHJzze0jIoAfM_0K4LDZY80QarRDRAPBzUse9EjejwsU1wuPzeMVbv4b0-2IDAV5dh1BMyBaY0OoPRIexmF9cVpoxsbMEPVh-XNziYF9ILDOGCcJ33W-B2HeNX9AEmHTd1uqJinL70ocH5aHU6PkCLAW-40552NV7dNrd4U4v0ARqJg4hZyfkfu5Cf3YYAYwOY9aIZvWPn68PUO33iWx9J-F290s0hgU7-USEEYifgyah68FxXhUQp9E4hwp81CQgHu36HdZq-YZN0hBQene7GfaPNIQI0hk7LVlfj1CS8Xv2OHZpMQ",
+              "type": "string"
+            }
+          ]
         },
         "method": "POST",
         "header": [],
@@ -302,7 +350,12 @@
             }
           }
         },
-        "url": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/report"
+        "url": {
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/details/report",
+          "protocol": "https",
+          "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "route", "details", "report"]
+        }
       },
       "response": []
     },
@@ -311,9 +364,13 @@
       "request": {
         "auth": {
           "type": "bearer",
-          "bearer": {
-            "token": "eyJraWQiOiJvWnBBeWVqKzJEdGk0REUrczFpZnAycURUU0ZnNWVwSFNId3hIMDlcL1VMcz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiI3Y2RkZGIyMy1hNjNkLTRmMTctYmUyNy0xZjA3OGIxZWQzMDIiLCJldmVudF9pZCI6IjVhOWY3NzIxLTFmNTUtNDNiNy04ZGIyLWQ5ZDdiODllZjgzOCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MjM0NzM2MTYsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV8xN0VWUXloODIiLCJleHAiOjE2MjM1NjAwMTYsImlhdCI6MTYyMzQ3MzYxNywianRpIjoiOGRkZjM1ODgtNmUzMi00YWUxLTgxZTAtOGIyZGNjNzdjZjgzIiwiY2xpZW50X2lkIjoiZzVwNHZxNjFtYmZjbWVzb282dnNqa2c2cCIsInVzZXJuYW1lIjoiN2NkZGRiMjMtYTYzZC00ZjE3LWJlMjctMWYwNzhiMWVkMzAyIn0.L5L9CUjjFqeIY7acuY_rAeKPND7lJFUGi4qbK2CCz10LVlmJS53Uhe2Q23GYzQ06vy9rsBIgpYe8JVrO0T2IBGdKjOsRQxAreL-SIjUrOUQFfb0Gsxa8_5rBu62w_9WT2fvxMA9k3ss75W3ORPGQ6y6yMjGO8Ni5YzcusLPdrsM5_PF1RWhVyU-PSC0eniyGpSQcMVJ9setgZlXeBEL88D3HXK-Qd_rOLZfFLbF7YuW_p4dXm6QfEwKwzfEuxSf6hNY0y1oQlPkpeFpPwPhAAfaHMs6_CnflJ09pA2O-nFWdIMN8Fh_3N9_pwSc4d7zNG9rpikCSzfJpljC7pfNb-w"
-          }
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiZDMwMWE3ZjUtN2MyZi00YThmLWFmODItNmRmNWRkODZhNGJhIiwic3ViIjoiZThjYzQwNTItM2YxZS00MzgwLWFiNjEtNjM3MzVlYmMwMDUyIiwiZXZlbnRfaWQiOiIxZTU0NGQ1ZS1mMDk4LTQ3ODQtOGQ4MC0xNzEyNjVhYzQxMDAiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODU0NjY4LCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTQxMDY4LCJpYXQiOjE2MjM4NTQ2NjgsImp0aSI6IjY0ZDUwNGQ3LTU1MWUtNGE1Ny1iMDI5LTc5ZjU0YjQ5MzJjMyIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.hIyVrUvJMOnI_dnYJOuD-yiTFhCUnH9eWy0NoU1KmYTwSS58sETeG9ezy--0EjRHDgOLtP7f4HofeOiour9eUglUMB1AciXcA_X5f5Il9aaWxHeVhpG0WRygIFNACu_jEKJxm1nCVAi-6mGw0u8gsLOWSf_VWOtxuWihMjI5eZzLJqnYrA5AfSb5f9IuC6SnDZgtlS5Y6oBp4ZvCxrNedVJTFSxVv9_0BVDK160d9KCnocAuw856khEM6Gbg-LkVeWVPXyx006GszKgQI4bMMl3qk0PPuw4uYZ7YWJ1UlSA1vZ1SmGzQofVoPjHx3ENcFV64gXNI1-LrXfG9its9VA",
+              "type": "string"
+            }
+          ]
         },
         "method": "POST",
         "header": [],
@@ -326,7 +383,12 @@
             }
           }
         },
-        "url": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/gym/request"
+        "url": {
+          "raw": "https://g09kmjici5.execute-api.ap-southeast-1.amazonaws.com/dev/route/gym/request",
+          "protocol": "https",
+          "host": ["g09kmjici5", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "route", "gym", "request"]
+        }
       },
       "response": []
     }

--- a/lambda_backend/postman_collections/Bouldering - User.postman_collection.json
+++ b/lambda_backend/postman_collections/Bouldering - User.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "_postman_id": "86ec4b97-f4fd-4b3b-8b4d-7e3268aa7209",
     "name": "Bouldering - User",
-    "schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
     {
@@ -19,7 +19,12 @@
             }
           }
         },
-        "url": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/signup"
+        "url": {
+          "raw": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/signup",
+          "protocol": "https",
+          "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "user", "signup"]
+        }
       },
       "response": []
     },
@@ -30,14 +35,19 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"email\": \"yarkhinephyo@gmail.com\",\r\n    \"code\": \"147310\"\r\n}",
+          "raw": "{\r\n    \"name\": \"yarkhinephyo\",\r\n    \"code\": \"536856\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
             }
           }
         },
-        "url": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/confirm"
+        "url": {
+          "raw": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/confirm",
+          "protocol": "https",
+          "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "user", "confirm"]
+        }
       },
       "response": []
     },
@@ -48,14 +58,19 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"email\": \"yarkhinephyo@gmail.com\"\r\n}",
+          "raw": "{\r\n    \"name\": \"yarkhinephyo\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
             }
           }
         },
-        "url": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/resendCode"
+        "url": {
+          "raw": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/resendCode",
+          "protocol": "https",
+          "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "user", "resendCode"]
+        }
       },
       "response": []
     },
@@ -66,14 +81,19 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"email\": \"yarkhinephyo@gmail.com\"\r\n}",
+          "raw": "{\r\n    \"name\": \"yarkhinephyo\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
             }
           }
         },
-        "url": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/forgotPassword"
+        "url": {
+          "raw": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/forgotPassword",
+          "protocol": "https",
+          "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "user", "forgotPassword"]
+        }
       },
       "response": []
     },
@@ -84,14 +104,19 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"email\": \"yarkhinephyo@gmail.com\",\r\n    \"password\": \"Qwer!234\",\r\n    \"code\": \"659676\"\r\n}",
+          "raw": "{\r\n    \"name\": \"yarkhinephyo\",\r\n    \"password\": \"Qwer!234\",\r\n    \"code\": \"013975\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
             }
           }
         },
-        "url": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/resetPassword"
+        "url": {
+          "raw": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/resetPassword",
+          "protocol": "https",
+          "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "user", "resetPassword"]
+        }
       },
       "response": []
     },
@@ -102,14 +127,19 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\r\n    \"email\": \"yarkhinephyo@gmail.com\",\r\n    \"password\": \"Qwer!234\"\r\n}",
+          "raw": "{\r\n    \"name\": \"yarkhinephyo\",\r\n    \"password\": \"Qwer!234\"\r\n}",
           "options": {
             "raw": {
               "language": "json"
             }
           }
         },
-        "url": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/login"
+        "url": {
+          "raw": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/login",
+          "protocol": "https",
+          "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "user", "login"]
+        }
       },
       "response": []
     },
@@ -127,7 +157,12 @@
             }
           }
         },
-        "url": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/refreshToken"
+        "url": {
+          "raw": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/refreshToken",
+          "protocol": "https",
+          "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "user", "refreshToken"]
+        }
       },
       "response": []
     },
@@ -136,9 +171,13 @@
       "request": {
         "auth": {
           "type": "bearer",
-          "bearer": {
-            "token": "eyJraWQiOiJvWnBBeWVqKzJEdGk0REUrczFpZnAycURUU0ZnNWVwSFNId3hIMDlcL1VMcz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJlZmYzZDYzYi0wY2QyLTRmNmYtOTJkYS04OGRjZTYzMDA0ZjAiLCJldmVudF9pZCI6IjQ2MDg1YTg0LWNlZWYtNDE5ZS1hYTkyLWVhMTI0NDc3YWE1NiIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MjM2ODEwOTEsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV8xN0VWUXloODIiLCJleHAiOjE2MjM3Njc0OTEsImlhdCI6MTYyMzY4MTA5MSwianRpIjoiNDgyYzllZmMtMTUwYS00NzUzLWI0OTctNTk5ZWVmMmY3YTkwIiwiY2xpZW50X2lkIjoiZzVwNHZxNjFtYmZjbWVzb282dnNqa2c2cCIsInVzZXJuYW1lIjoiZWZmM2Q2M2ItMGNkMi00ZjZmLTkyZGEtODhkY2U2MzAwNGYwIn0.JQjKf3b5K1hkPParfVDDwjRpg7K9wS3b-Cnbewhoxly2da_IkIxnEAF1BH0ph3jwvfV5QAnKS8mWU48em8xKfdk9injmQcEar9NGsk7jQSedplHlfORsH8uJDUX5zqFH0BjKOi7cVxyr4Y5q59dAZbktri4apkqcv0azv77BkllH8ibCLHFXbiyI2H6daxDpqR3-yMd77qkV-WYxnIeQh64t-dpIx1RNGacUnWJkEN7F22J2hlRdarzgFea_XUkaZqrFAKwAfAMahACQU0m6SmP-7ZQFJgA6OQDA95OVbWzHNFLwmqgJEClUPTk2pDEpY80tUb5Zn1pdysnR_mYvZg"
-          }
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJraWQiOiJvWnBBeWVqKzJEdGk0REUrczFpZnAycURUU0ZnNWVwSFNId3hIMDlcL1VMcz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJlZmYzZDYzYi0wY2QyLTRmNmYtOTJkYS04OGRjZTYzMDA0ZjAiLCJldmVudF9pZCI6IjQ2MDg1YTg0LWNlZWYtNDE5ZS1hYTkyLWVhMTI0NDc3YWE1NiIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MjM2ODEwOTEsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV8xN0VWUXloODIiLCJleHAiOjE2MjM3Njc0OTEsImlhdCI6MTYyMzY4MTA5MSwianRpIjoiNDgyYzllZmMtMTUwYS00NzUzLWI0OTctNTk5ZWVmMmY3YTkwIiwiY2xpZW50X2lkIjoiZzVwNHZxNjFtYmZjbWVzb282dnNqa2c2cCIsInVzZXJuYW1lIjoiZWZmM2Q2M2ItMGNkMi00ZjZmLTkyZGEtODhkY2U2MzAwNGYwIn0.JQjKf3b5K1hkPParfVDDwjRpg7K9wS3b-Cnbewhoxly2da_IkIxnEAF1BH0ph3jwvfV5QAnKS8mWU48em8xKfdk9injmQcEar9NGsk7jQSedplHlfORsH8uJDUX5zqFH0BjKOi7cVxyr4Y5q59dAZbktri4apkqcv0azv77BkllH8ibCLHFXbiyI2H6daxDpqR3-yMd77qkV-WYxnIeQh64t-dpIx1RNGacUnWJkEN7F22J2hlRdarzgFea_XUkaZqrFAKwAfAMahACQU0m6SmP-7ZQFJgA6OQDA95OVbWzHNFLwmqgJEClUPTk2pDEpY80tUb5Zn1pdysnR_mYvZg",
+              "type": "string"
+            }
+          ]
         },
         "method": "POST",
         "header": [],
@@ -146,7 +185,12 @@
           "mode": "raw",
           "raw": ""
         },
-        "url": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/logout"
+        "url": {
+          "raw": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/logout",
+          "protocol": "https",
+          "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "user", "logout"]
+        }
       },
       "response": []
     },
@@ -155,13 +199,22 @@
       "request": {
         "auth": {
           "type": "bearer",
-          "bearer": {
-            "token": "eyJraWQiOiJvWnBBeWVqKzJEdGk0REUrczFpZnAycURUU0ZnNWVwSFNId3hIMDlcL1VMcz0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiI5YTEyNTFhMi01NGE5LTQ2YzgtYTk4Yy03YmJkMWU5NTAyYWMiLCJldmVudF9pZCI6IjQxNTY1ZmI4LTk3NTEtNGNhMy1iYzlkLWNlZmJkODBhNzQ3ZCIsInRva2VuX3VzZSI6ImFjY2VzcyIsInNjb3BlIjoiYXdzLmNvZ25pdG8uc2lnbmluLnVzZXIuYWRtaW4iLCJhdXRoX3RpbWUiOjE2MjM2NjcwMzAsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMS5hbWF6b25hd3MuY29tXC9hcC1zb3V0aGVhc3QtMV8xN0VWUXloODIiLCJleHAiOjE2MjM3NTM0MzAsImlhdCI6MTYyMzY2NzAzMCwianRpIjoiNzE3YmM2NjMtYTk4NC00NzdlLWIyMTYtYjM0NGE3ODE2ZjdkIiwiY2xpZW50X2lkIjoiZzVwNHZxNjFtYmZjbWVzb282dnNqa2c2cCIsInVzZXJuYW1lIjoiOWExMjUxYTItNTRhOS00NmM4LWE5OGMtN2JiZDFlOTUwMmFjIn0.E6YThuB17PKaTlVvaI_ukdm6e3WXvZ7RnjxWGFHck_CFjGZriibJw-JVZC4jnbR215MS_J9QEBlGec8P_MOR-2_Dby8r58gMZ8shy5PydJGCzVSBX_ENnrDJBkRoJhI8Wj07rFOFhMzXHeUiW04oSlkQKP8cumaiIuR55n3ETcxtJRUtuxe6tgzPUCuLfkUrfSPqTeGu6coXE-_9oMtwa41Dp7fCQFwMn-ZV0xLTQyq6WLruhG5hZFqnBwdKqDOVB8HL2UpaU3DM1jkuVfb9CqstJl0tJMdGw_ZmearTO4R_ET8B_QJb54UwssOrl2aFNb_tm1PYtNSeDhKMpjjUQQ"
-          }
+          "bearer": [
+            {
+              "key": "token",
+              "value": "eyJraWQiOiJVa3o4cUVIV1FVazZ4dTl5M1VtTGJHT2hldUZZOWRxZWR4bU80YmNEU0VzPSIsImFsZyI6IlJTMjU2In0.eyJvcmlnaW5fanRpIjoiZWEzZGJiMjAtMGQ4Yy00Yzk3LTkyNzctOGIwYWI2OGZiNTdmIiwic3ViIjoiZjY4MzhlMGMtMTBlOC00YWNlLTg3ZmQtMjRhMGY0Mzc4Zjc4IiwiZXZlbnRfaWQiOiI0MGQ2NjYyYy03NWQ3LTQyZjgtOGI3ZC0zMmI3NTg2NDYxMTYiLCJ0b2tlbl91c2UiOiJhY2Nlc3MiLCJzY29wZSI6ImF3cy5jb2duaXRvLnNpZ25pbi51c2VyLmFkbWluIiwiYXV0aF90aW1lIjoxNjIzODUyMzcwLCJpc3MiOiJodHRwczpcL1wvY29nbml0by1pZHAuYXAtc291dGhlYXN0LTEuYW1hem9uYXdzLmNvbVwvYXAtc291dGhlYXN0LTFfVWxTOFNWQ3V1IiwiZXhwIjoxNjIzOTM4NzcwLCJpYXQiOjE2MjM4NTIzNzAsImp0aSI6ImU5ZmU4NTEyLThhNTQtNDBhNS04ZjVkLWFhYjRhNmE3NGYwMSIsImNsaWVudF9pZCI6IjNncHRrdmpmcG9xaXVuZWptMnNpbmNqaWVmIiwidXNlcm5hbWUiOiJ5YXJraGluZXBoeW8ifQ.cSqq_bC4t23JOVp7NkdFCLQFPTud-EMSlvHcPKsmgXw9I43K2Ir0FvzR6D1e2-YFAxcDHkJuqe04gqs3etrqj04DFGMQi04hKrDZGG4q-JLhtgl9b2UIpYCANfqajkctbxdVvmfYDzpOpdggnIjpiPOSg-krx2Sa2CB86yoGHD0LKpwDHryS-V_k7ub5j3qo4i_B65rPiDBcmzaN_iqXDkxIM2yIfbl9Julw1XZj9wYYAV1dzfEdj5rNfUtp-DWXfS-9UcvcSD3bpVoRVLhtoXVOYvRENUpQNoM_yX4LDgU182WxkX_i9NtEp4gwBYRql_Jif44Nr_1Qee86j4SL8g",
+              "type": "string"
+            }
+          ]
         },
         "method": "DELETE",
         "header": [],
-        "url": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/delete"
+        "url": {
+          "raw": "https://t5afrkn47j.execute-api.ap-southeast-1.amazonaws.com/dev/user/delete",
+          "protocol": "https",
+          "host": ["t5afrkn47j", "execute-api", "ap-southeast-1", "amazonaws", "com"],
+          "path": ["dev", "user", "delete"]
+        }
       },
       "response": []
     }

--- a/lambda_backend/route_microservice/src/addComment.ts
+++ b/lambda_backend/route_microservice/src/addComment.ts
@@ -3,7 +3,6 @@ import DynamoDB, { AttributeValue, UpdateItemInput } from 'aws-sdk/clients/dynam
 import {
   getMiddlewareAddedHandler,
   getItemFromRouteTable,
-  getCognitoUserDetails,
   addCommentSchema,
   AddCommentEvent,
   Comment,
@@ -27,12 +26,10 @@ const addComment: Handler = async (event: AddCommentEvent) => {
 
   const accessToken = Authorization.split(' ')[1];
   const { username } = (await jwt_decode(accessToken)) as JwtPayload;
-  const displayName = (await getCognitoUserDetails(accessToken)).fullName;
   let { comments } = Item;
   const newComment: Comment = {
     username,
     timestamp: Date.now(),
-    displayName,
     comment: commentStr,
   };
   comments = [...comments, newComment];

--- a/lambda_backend/route_microservice/src/common/cognito.ts
+++ b/lambda_backend/route_microservice/src/common/cognito.ts
@@ -36,7 +36,5 @@ export const adminGetCognitoUserDetails = async (Username: string): Promise<Cogn
 const parseUserAttributes = (UserAttributes: AttributeType[]): CognitoUserDetails => {
   const userEmail = UserAttributes.filter((attribute) => attribute.Name === 'email')[0]
     .Value as string;
-  const fullName = UserAttributes.filter((attribute) => attribute.Name === 'name')[0]
-    .Value as string;
-  return { fullName, userEmail };
+  return { userEmail };
 };

--- a/lambda_backend/route_microservice/src/common/types.ts
+++ b/lambda_backend/route_microservice/src/common/types.ts
@@ -104,7 +104,6 @@ interface GradeSubmission {
 export interface Comment {
   username: string;
   timestamp: number;
-  displayName: string;
   comment: string;
 }
 
@@ -112,7 +111,6 @@ export interface RouteItem {
   username: string;
   createdAt: string;
   ttl: number;
-  displayName: string;
   routeName: string;
   gymLocation: string;
   routeURL: string;
@@ -127,7 +125,6 @@ export interface RouteItem {
 }
 
 export interface CognitoUserDetails {
-  fullName: string;
   userEmail: string;
 }
 

--- a/lambda_backend/route_microservice/src/createRoute.ts
+++ b/lambda_backend/route_microservice/src/createRoute.ts
@@ -9,7 +9,6 @@ import {
   createRouteSchema,
   JwtPayload,
   RouteItem,
-  getCognitoUserDetails,
 } from './common';
 import { MAX_PHOTO_SIZE } from './config';
 import { createHash } from 'crypto';
@@ -65,13 +64,10 @@ const createRoute: Handler = async (event: CreateRouteEvent) => {
     throw createError(500, 'S3 upload failed.' + error.stack);
   }
 
-  const displayName = (await getCognitoUserDetails(accessToken)).fullName;
-
   const routeItem: RouteItem = {
     username,
     createdAt,
     ttl: new Date(expiredTime).getTime(),
-    displayName,
     routeName,
     gymLocation,
     routeURL,

--- a/lambda_backend/route_microservice/src/getRouteDetails.ts
+++ b/lambda_backend/route_microservice/src/getRouteDetails.ts
@@ -26,7 +26,6 @@ const getRouteDetails: Handler = async (event: GetRouteDetailsEvent) => {
   let graded = -1;
   const {
     ttl,
-    displayName,
     routeName,
     gymLocation,
     routeURL,
@@ -65,7 +64,6 @@ const getRouteDetails: Handler = async (event: GetRouteDetailsEvent) => {
         username: routeOwnerUsername,
         createdAt,
         expiredTime: new Date(ttl).toISOString(),
-        displayName,
         routeName,
         gymLocation,
         routeURL,

--- a/lambda_backend/route_microservice/src/getRoutesByGym.ts
+++ b/lambda_backend/route_microservice/src/getRoutesByGym.ts
@@ -16,6 +16,7 @@ const getRoutesByGym: Handler = async (event: GetRoutesByGymEvent) => {
     TableName: process.env['ROUTE_TABLE_NAME'],
     IndexName: 'gymLocationIndex',
     ConsistentRead: false,
+    ScanIndexForward: false,
     KeyConditionExpression: 'gymLocation = :gymLocation',
     ExpressionAttributeValues: {
       ':gymLocation': gymLocation as AttributeValue,

--- a/lambda_backend/user_microservice/serverless.yml
+++ b/lambda_backend/user_microservice/serverless.yml
@@ -12,6 +12,7 @@ provider:
     NODE_ENV: ${self:custom.stage}
     ALLOWED_ORIGIN: ${self:custom._origin.${self:custom.stage}}
     COGNITO_CLIENT_ID: ${self:custom.cognitoClientId}
+    COGNITO_USERPOOL_ID: ${self:custom.cognitoUserpoolId}
   logRetentionInDays: 30
   lambdaHashingVersion: 20201221
   iam:
@@ -22,6 +23,10 @@ provider:
             - cognito-idp:SignUp
             - cognito-idp:ConfirmSignUp
             - cognito-idp:InitiateAuth
+          Resource: ${self:custom.cognitoArn}
+        - Effect: Allow
+          Action:
+            - cognito-idp:AdminGetUser
           Resource: ${self:custom.cognitoArn}
 
 plugins:
@@ -122,6 +127,7 @@ custom:
   stage: ${opt:stage, self:provider.stage}
   cognitoArn: ${ssm:/${self:custom.stage}/cognito/arn}
   cognitoClientId: ${ssm:/${self:custom.stage}/cognito/clientId}
+  cognitoUserpoolId: ${ssm:/${self:custom.stage}/cognito/poolId}
   apiGatewayThrottling:
     maxRequestsPerSecond: ${self:custom._maxRequestsPerSecond.${self:custom.stage}}
     maxConcurrentRequests: ${self:custom._maxConcurrentRequests.${self:custom.stage}}

--- a/lambda_backend/user_microservice/src/common/identityProvider.ts
+++ b/lambda_backend/user_microservice/src/common/identityProvider.ts
@@ -1,0 +1,31 @@
+import CognitoIdentityServiceProvider, {
+  AdminGetUserRequest,
+  AttributeType,
+} from 'aws-sdk/clients/cognitoidentityserviceprovider';
+import createError from 'http-errors';
+
+const cognitoIdentity = new CognitoIdentityServiceProvider();
+
+export const adminGetCognitoUserDetails = async (Username: string): Promise<CognitoUserDetails> => {
+  const adminGetUserParams: AdminGetUserRequest = {
+    Username,
+    UserPoolId: process.env['COGNITO_USERPOOL_ID'] as string,
+  };
+  try {
+    const adminGetUserResponse = await cognitoIdentity.adminGetUser(adminGetUserParams).promise();
+    const UserAttributes = adminGetUserResponse.UserAttributes as AttributeType[];
+    return parseUserAttributes(UserAttributes);
+  } catch (error) {
+    throw createError(500, 'Error retrieving Cognito user details');
+  }
+};
+
+const parseUserAttributes = (UserAttributes: AttributeType[]): CognitoUserDetails => {
+  const userEmail = UserAttributes.filter((attribute) => attribute.Name === 'email')[0]
+    .Value as string;
+  return { userEmail };
+};
+
+interface CognitoUserDetails {
+  userEmail: string;
+}

--- a/lambda_backend/user_microservice/src/common/index.ts
+++ b/lambda_backend/user_microservice/src/common/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './schema';
 export * from './middleware';
+export * from './identityProvider';

--- a/lambda_backend/user_microservice/src/common/schema.ts
+++ b/lambda_backend/user_microservice/src/common/schema.ts
@@ -22,10 +22,10 @@ export const confirmSignupSchema = {
     body: {
       type: 'object',
       properties: {
-        email: { type: 'string', pattern: Email },
+        name: { type: 'string', pattern: AlphanumericSpace },
         code: { type: 'string', pattern: AlphanumericSpace },
       },
-      required: ['email', 'code'],
+      required: ['name', 'code'],
     },
   },
 };
@@ -36,30 +36,30 @@ export const loginSchema = {
     body: {
       type: 'object',
       properties: {
-        email: { type: 'string', pattern: Email },
+        name: { type: 'string', pattern: AlphanumericSpace },
         password: { type: 'string' },
       },
-      required: ['email', 'password'],
+      required: ['name', 'password'],
     },
   },
 };
 
-const emailIdentiferSchema = {
+const identiferSchema = {
   type: 'object',
   properties: {
     body: {
       type: 'object',
       properties: {
-        email: { type: 'string', pattern: Email },
+        name: { type: 'string', pattern: AlphanumericSpace },
       },
-      required: ['email'],
+      required: ['name'],
     },
   },
 };
 
-export const resendCodeSchema = emailIdentiferSchema;
+export const resendCodeSchema = identiferSchema;
 
-export const forgotPasswordSchema = emailIdentiferSchema;
+export const forgotPasswordSchema = identiferSchema;
 
 export const confirmForgotPasswordSchema = {
   type: 'object',

--- a/lambda_backend/user_microservice/src/common/schema.ts
+++ b/lambda_backend/user_microservice/src/common/schema.ts
@@ -9,7 +9,7 @@ export const signupSchema = {
       properties: {
         email: { type: 'string', pattern: Email },
         password: { type: 'string' },
-        name: { type: 'string', pattern: AlphanumericSpace },
+        name: { type: 'string', pattern: AlphanumericSpace, maxLength: 20 },
       },
       required: ['email', 'password', 'name'],
     },
@@ -22,7 +22,7 @@ export const confirmSignupSchema = {
     body: {
       type: 'object',
       properties: {
-        name: { type: 'string', pattern: AlphanumericSpace },
+        name: { type: 'string', pattern: AlphanumericSpace, maxLength: 20 },
         code: { type: 'string', pattern: AlphanumericSpace },
       },
       required: ['name', 'code'],
@@ -36,7 +36,7 @@ export const loginSchema = {
     body: {
       type: 'object',
       properties: {
-        name: { type: 'string', pattern: AlphanumericSpace },
+        name: { type: 'string', pattern: AlphanumericSpace, maxLength: 20 },
         password: { type: 'string' },
       },
       required: ['name', 'password'],
@@ -50,7 +50,7 @@ const identiferSchema = {
     body: {
       type: 'object',
       properties: {
-        name: { type: 'string', pattern: AlphanumericSpace },
+        name: { type: 'string', pattern: AlphanumericSpace, maxLength: 20 },
       },
       required: ['name'],
     },

--- a/lambda_backend/user_microservice/src/common/types.ts
+++ b/lambda_backend/user_microservice/src/common/types.ts
@@ -8,24 +8,24 @@ export interface SignupEvent {
 
 export interface ConfirmSignupEvent {
   body: {
-    email: string;
+    name: string;
     code: string;
   };
 }
 
-interface EmailIdentifer {
+interface UserIdentifer {
   body: {
-    email: string;
+    name: string;
   };
 }
 
-export type ResendCodeEvent = EmailIdentifer;
+export type ResendCodeEvent = UserIdentifer;
 
-export type ForgotPasswordEvent = EmailIdentifer;
+export type ForgotPasswordEvent = UserIdentifer;
 
 export interface ConfirmForgotPasswordEvent {
   body: {
-    email: string;
+    name: string;
     code: string;
     password: string;
   };
@@ -33,7 +33,7 @@ export interface ConfirmForgotPasswordEvent {
 
 export interface LoginEvent {
   body: {
-    email: string;
+    name: string;
     password: string;
   };
 }

--- a/lambda_backend/user_microservice/src/confirmForgotPassword.ts
+++ b/lambda_backend/user_microservice/src/confirmForgotPassword.ts
@@ -12,10 +12,10 @@ const cognitoIdentity = new CognitoIdentity();
 
 const confirmForgotPassword: Handler = async (event: ConfirmForgotPasswordEvent) => {
   const {
-    body: { code, email, password },
+    body: { code, name, password },
   } = event;
   const confirmForgotPasswordRequest: ConfirmForgotPasswordRequest = {
-    Username: email,
+    Username: name,
     ConfirmationCode: code,
     Password: password,
     ClientId: process.env['COGNITO_CLIENT_ID'] || '',

--- a/lambda_backend/user_microservice/src/confirmSignup.ts
+++ b/lambda_backend/user_microservice/src/confirmSignup.ts
@@ -8,10 +8,10 @@ const cognitoIdentity = new CognitoIdentity();
 
 const confirmSignup: Handler = async (event: ConfirmSignupEvent) => {
   const {
-    body: { email, code },
+    body: { name, code },
   } = event;
   const confirmSignUpRequest: ConfirmSignUpRequest = {
-    Username: email,
+    Username: name,
     ConfirmationCode: code,
     ClientId: process.env['COGNITO_CLIENT_ID'] || '',
   };

--- a/lambda_backend/user_microservice/src/forgotPassword.ts
+++ b/lambda_backend/user_microservice/src/forgotPassword.ts
@@ -8,10 +8,10 @@ const cognitoIdentity = new CognitoIdentity();
 
 const forgotPassword: Handler = async (event: ForgotPasswordEvent) => {
   const {
-    body: { email },
+    body: { name },
   } = event;
   const forgotPasswordRequest: ForgotPasswordRequest = {
-    Username: email,
+    Username: name,
     ClientId: process.env['COGNITO_CLIENT_ID'] || '',
   };
   try {

--- a/lambda_backend/user_microservice/src/login.ts
+++ b/lambda_backend/user_microservice/src/login.ts
@@ -2,7 +2,12 @@ import { Handler } from 'aws-lambda';
 import CognitoIdentity, {
   InitiateAuthRequest,
 } from 'aws-sdk/clients/cognitoidentityserviceprovider';
-import { LoginEvent, loginSchema, getMiddlewareAddedHandler } from './common';
+import {
+  LoginEvent,
+  loginSchema,
+  getMiddlewareAddedHandler,
+  adminGetCognitoUserDetails,
+} from './common';
 
 const cognitoIdentity = new CognitoIdentity();
 
@@ -27,10 +32,18 @@ const login: Handler = async (event: LoginEvent) => {
       body: JSON.stringify({ Message: 'Log in success', ...AuthenticationResult }),
     };
   } catch (error) {
-    return {
-      statusCode: 400,
-      body: JSON.stringify({ Message: error.code }),
-    };
+    if (error.code === 'UserNotConfirmedException') {
+      const { userEmail } = await adminGetCognitoUserDetails(name);
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ Message: error.code, Email: userEmail }),
+      };
+    } else {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ Message: error.code }),
+      };
+    }
   }
 };
 

--- a/lambda_backend/user_microservice/src/login.ts
+++ b/lambda_backend/user_microservice/src/login.ts
@@ -8,12 +8,12 @@ const cognitoIdentity = new CognitoIdentity();
 
 const login: Handler = async (event: LoginEvent) => {
   const {
-    body: { email, password },
+    body: { name, password },
   } = event;
   const initiateAuthRequest: InitiateAuthRequest = {
     AuthFlow: 'USER_PASSWORD_AUTH',
     AuthParameters: {
-      USERNAME: email,
+      USERNAME: name,
       PASSWORD: password,
     },
     ClientId: process.env['COGNITO_CLIENT_ID'] || '',

--- a/lambda_backend/user_microservice/src/resendCode.ts
+++ b/lambda_backend/user_microservice/src/resendCode.ts
@@ -8,10 +8,10 @@ const cognitoIdentity = new CognitoIdentity();
 
 const resendCode: Handler = async (event: ResendCodeEvent) => {
   const {
-    body: { email },
+    body: { name },
   } = event;
   const resendConfirmationCodeRequest: ResendConfirmationCodeRequest = {
-    Username: email,
+    Username: name,
     ClientId: process.env['COGNITO_CLIENT_ID'] || '',
   };
   try {

--- a/lambda_backend/user_microservice/src/signup.ts
+++ b/lambda_backend/user_microservice/src/signup.ts
@@ -9,12 +9,9 @@ const signup: Handler = async (event: SignupEvent) => {
     body: { email, name, password },
   } = event;
   const signUpRequest: SignUpRequest = {
-    Username: email,
+    Username: name,
     Password: password,
-    UserAttributes: [
-      { Name: 'email', Value: email },
-      { Name: 'name', Value: name },
-    ],
+    UserAttributes: [{ Name: 'email', Value: email }],
     ClientId: process.env['COGNITO_CLIENT_ID'] || '',
   };
   try {


### PR DESCRIPTION
#### Summary
Instead of using email as identifier for the users in Cognito, we use unique usernames instead. This makes it easier to utilize user identifiers in the frontend as email is considered more sensitive.

#### Changes
- Refactoring was done for the frontend for logging in and signing up
  - No feature change except now you use username to log in
- Removal of displayName in the backend as it used to store the usernames
- Updated Postman and Swagger